### PR TITLE
Introduce a force flag to overwrite doc-properties of a wrong type.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,8 @@ Changelog
 1.2.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Introduce a force flag to overwrite doc-properties of a wrong type.
+  [deiferni]
 
 
 1.2.0 (2016-10-04)

--- a/ooxml_docprops/tests/test_doc_properties.py
+++ b/ooxml_docprops/tests/test_doc_properties.py
@@ -1,3 +1,5 @@
+from datetime import datetime
+from ooxml_docprops.datatypes import ValidationError
 from ooxml_docprops.properties import OOXMLDocument
 from ooxml_docprops.tests.assets import TestAsset
 from unittest2 import TestCase
@@ -41,3 +43,22 @@ class TestDocProperties(TestCase):
 
                 self.assertEqual('Hanspeter',
                                  doc.properties.get_property_value('Test'))
+
+    def test_properties_with_different_type_can_be_updated_in_force_mode(self):
+        with TestAsset('with_custom_properties.docx') as asset:
+            with OOXMLDocument(asset.path, force=True) as doc:
+                self.assertEqual('Peter',
+                                 doc.properties.get_property_value('Test'))
+                now = datetime.now()
+                doc.update_properties({'Test': now})
+
+                self.assertEqual(now,
+                                 doc.properties.get_property_value('Test'))
+
+    def test_properties_with_different_type_raise_in_non_force_mode(self):
+        with TestAsset('with_custom_properties.docx') as asset:
+            with OOXMLDocument(asset.path) as doc:
+                self.assertEqual('Peter',
+                                 doc.properties.get_property_value('Test'))
+                with self.assertRaises(ValidationError):
+                    doc.update_properties({'Test': datetime.now()})


### PR DESCRIPTION
This PR introduces a `force` flag option for `OOXMLDocument`. If set to `True` doc-properties of a wrong type are overwritten with properties of the desired type.
